### PR TITLE
feat: Modify project permission system

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-darwin)
+      racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
@@ -298,6 +300,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -18,15 +18,17 @@ class ProjectsController < ProjectsBaseController
   end
 
   def create
-    project = Project.create!(
-      title: params[:name],
-      team: current_user.team,
-      public_feed: params[:visibility] == 'Public'
-    )
-    ProjectUser.create!(
-      project: project,
-      user_id: current_user.id
-    )
+    Project.transaction do
+      project = Project.create!(
+        title: params[:name],
+        team: current_user.team,
+        public_feed: params[:visibility] == 'Public'
+      )
+      ProjectUser.create!(
+        project: project,
+        user_id: current_user.id
+      )
+    end
 
     flash[:success] = 'Project created'
     return redirect_to dashboard_path

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,6 +23,10 @@ class ProjectsController < ProjectsBaseController
       team: current_user.team,
       public_feed: params[:visibility] == 'Public'
     )
+    ProjectUser.create!(
+      project: project,
+      user_id: current_user.id
+    )
 
     flash[:success] = 'Project created'
     return redirect_to dashboard_path

--- a/app/src/projects_for_user.rb
+++ b/app/src/projects_for_user.rb
@@ -10,10 +10,9 @@ class ProjectsForUser
 
   def run
     return [] if @user.deleted
-    projects.map do |project|
-      next unless user_on_project?(project)
-      project
-    end.compact.sort_by(&:title)
+    projects.filter_map do |project|
+      project if user_on_project?(project)
+    end.sort_by(&:title)
   end
 
   private
@@ -24,7 +23,6 @@ class ProjectsForUser
 
   def user_on_project?(project)
     users = project.project_users
-    return true if users.empty?
     return true if @user.super_user
     users.map(&:user_id).include? @user.id
   end

--- a/spec/requests/releases/index_spec.rb
+++ b/spec/requests/releases/index_spec.rb
@@ -76,7 +76,7 @@ describe 'releases' do
 
   context "when requesting a project not owned by team" do
     let(:project1) { create(:project, :with_team) }
-    it 'lists the releases for the particular project' do
+    it 'returns an access forbidden error' do
       get api_project_releases_path(project_public_key: project1.public_key), params: {},
           headers: team_auth_headers(project.team)
       expect(parsed_response).to eq({'error' => 'forbidden'})

--- a/spec/src/user_permission_to_project_spec.rb
+++ b/spec/src/user_permission_to_project_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe UserPermissionToProject do
 
     context "when the project DOES NOT have a specific user list" do
       it "returns true" do
-        expect(subject.run).to eq(true)
+        expect(subject.run).to eq(false)
       end
     end
   end

--- a/spec/src/user_permission_to_project_spec.rb
+++ b/spec/src/user_permission_to_project_spec.rb
@@ -17,43 +17,31 @@ RSpec.describe UserPermissionToProject do
       end
     end
 
-    context "when the project has a specific user list" do
+    context "when the user is on the project user list" do
       before do
-        create(:project_user, project: project, user: create(:user, team: project.team))
+        create(:project_user, project: project, user: user)
+       end
+
+      it "returns true" do
+        expect(subject.run).to eq(true)
+      end
+    end
+
+    context "when the user is NOT on the project user list" do
+      context "and the user is not a super user" do
+        it "returns false" do
+          expect(subject.run).to eq(false)
+        end
       end
 
-      context "and the user is on that list" do
+      context "and the user is a super user" do
         before do
-          create(:project_user, project: project, user: user)
+          user.update(super_user: true)
         end
 
         it "returns true" do
           expect(subject.run).to eq(true)
         end
-      end
-
-      context "and the user is NOT on that list" do
-        context "and the user is not a super user" do
-          it "returns false" do
-            expect(subject.run).to eq(false)
-          end
-        end
-
-        context "and the user is a super user" do
-          before do
-            user.update(super_user: true)
-          end
-
-          it "returns true" do
-            expect(subject.run).to eq(true)
-          end
-        end
-      end
-    end
-
-    context "when the project DOES NOT have a specific user list" do
-      it "returns true" do
-        expect(subject.run).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Modify the project permission system so new projects are not automatically visible to all team members.
* add current user to project's `ProjectUsers` upon project creation
* projects are only visible to `ProjectUsers`
* clarify wording of `UserPermissionToProject` specs to reflect changes